### PR TITLE
Add method with ConnectionFactory as an argument

### DIFF
--- a/falchion-jetty9-connector/src/main/java/net/unit8/falchion/jetty9/ReusePortConnector.java
+++ b/falchion-jetty9-connector/src/main/java/net/unit8/falchion/jetty9/ReusePortConnector.java
@@ -1,5 +1,6 @@
 package net.unit8.falchion.jetty9;
 
+import org.eclipse.jetty.server.ConnectionFactory;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.util.annotation.Name;
@@ -16,6 +17,10 @@ import java.nio.channels.ServerSocketChannel;
 public class ReusePortConnector extends ServerConnector {
     public ReusePortConnector(@Name("server") Server server) {
         super(server);
+    }
+
+    public ReusePortConnector(@Name("server") Server server, @Name("factories") ConnectionFactory... factories) {
+        super(server, factories);
     }
 
     @Override


### PR DESCRIPTION
I want to use ReusePortConnector like ServerConnector in enkan-component-jetty/JettyAdapter#createHttpConnector.
